### PR TITLE
Dialogmøte med NAV til uke 17 i tidslinjen og bumpet nav-frontend avh.

### DIFF
--- a/js/reducers/tidslinjer.js
+++ b/js/reducers/tidslinjer.js
@@ -49,7 +49,7 @@ export const leggTilBilder = (_tidslinjer) => {
 };
 
 export const leggTilTidshendelser = (_tidslinjer, arbeidssituasjon) => {
-    let uker = [4, 7, 8, 26, 39];
+    let uker = [4, 7, 17, 26, 39];
     if (arbeidssituasjon === TIDSLINJE_TYPER.UTEN_ARBEIDSGIVER) {
         uker = [8, 12, 39];
     }

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "linttest:fix": "eslint tests/. --ext .js --fix"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/navikt/digisyfo-npm.git"
+    "type": "git",
+    "url": "https://github.com/navikt/digisyfo-npm.git"
   },
   "bugs": {
-    "url" : "https://github.com/navikt/digisyfo-npm/issues",
-    "email" : "digisyfo@nav.no"
+    "url": "https://github.com/navikt/digisyfo-npm/issues",
+    "email": "digisyfo@nav.no"
   },
   "license": "MIT",
   "author": "NAV",
   "dependencies": {
     "fetch-ponyfill": "4.1.0",
-    "nav-frontend-modal": "1.0.7",
-    "nav-frontend-hjelpetekst": "1.0.15"
+    "nav-frontend-modal": "1.0.23",
+    "nav-frontend-hjelpetekst": "1.0.37"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
@@ -57,16 +57,15 @@
     "ignore-styles": "5.0.1",
     "jsdom": "11.3.0",
     "mocha": "4.0.0",
-    "nav-frontend-core": "4.0.5",
-    "nav-frontend-hjelpetekst-style": "0.3.14",
-    "nav-frontend-ikoner-assets": "0.2.27",
-    "nav-frontend-lukknapp": "1.0.6",
-    "nav-frontend-lukknapp-style": "0.2.7",
-    "nav-frontend-modal": "1.0.7",
-    "nav-frontend-modal-style": "0.3.12",
-    "nav-frontend-paneler-style": "0.3.9",
-    "nav-frontend-typografi": "2.0.5",
-    "nav-frontend-typografi-style": "1.0.9",
+    "nav-frontend-core": "4.0.9",
+    "nav-frontend-hjelpetekst-style": "0.3.28",
+    "nav-frontend-ikoner-assets": "1.0.1",
+    "nav-frontend-lukknapp": "1.0.20",
+    "nav-frontend-lukknapp-style": "0.2.19",
+    "nav-frontend-modal-style": "0.3.27",
+    "nav-frontend-paneler-style": "0.3.14",
+    "nav-frontend-typografi": "2.0.10",
+    "nav-frontend-typografi-style": "1.0.12",
     "parallelshell": "2.0.0",
     "prop-types": "15.6.0",
     "react": "16.5.2",

--- a/tests/mock/mockLedetekster.js
+++ b/tests/mock/mockLedetekster.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 const ledetekster = {
+    'tidslinje.antall-uker.17': '17 Uker',
     'roller.sidetittel': 'Hvem gjør hva når du er sykmeldt',
     'tidslinje.med-arbeidsgiver.aktivitetskrav.budskap': '<p>NAV har som oppgave å vurdere om du fyller kravene til aktivitet og om du fortsatt har rett til sykepenger. Den som har sykmeldt deg skal gi NAV informasjon hvis medisinske forhold gjør at du ikke kan være i aktivitet.  Ved alvorlig sykdom er det unntak fra aktivitetsplikten. Du vil motta et brev fra NAV hvis vi er usikre på om du fyller aktivitetskravet. </p><p>Ved 8 uker vurderer NAV <a href="https://www.nav.no/no/Person/Arbeid/Sykmeldt%2C+arbeidsavklaringspenger+og+yrkesskade/Sykepenger/Sykepenger+til+arbeidstakere#chapter-2">aktivitetskravet</a>.</p>',
     'tidslinje.introtekst': 'Oppgavene på tidslinjen er generell informasjon om aktiviteter og milepæler. Aktiviteter kan skje på andre tidspunkter hvis det er behov for det. Hvis du er for syk til å delta i aktivitet, er det unntak fra oppgavene.',

--- a/tests/reducers/tidslinjerReducerTest.js
+++ b/tests/reducers/tidslinjerReducerTest.js
@@ -38,9 +38,9 @@ describe('tidslinjer', () => {
                 hendelser: [{
                     antallDager: 0,
                 }, {
-                    antallDager: 28,
+                    antallDager: 29,
                 }, {
-                    antallDager: 49,
+                    antallDager: 50,
                 }],
             }]);
             const res = leggTilTidshendelser(data);
@@ -51,20 +51,20 @@ describe('tidslinjer', () => {
                     tekstkey: 'tidslinje.sykefravaeret-starter',
                 }, {
                     antallDager: 28,
-                }, {
-                    antallDager: 28,
                     type: 'TID',
                     tekstkey: 'tidslinje.antall-uker.4',
                 }, {
-                    antallDager: 49,
+                    antallDager: 29,
                 }, {
                     antallDager: 49,
                     type: 'TID',
                     tekstkey: 'tidslinje.antall-uker.7',
                 }, {
-                    antallDager: 56,
+                    antallDager: 50,
+                }, {
+                    antallDager: 119,
                     type: 'TID',
-                    tekstkey: 'tidslinje.antall-uker.8',
+                    tekstkey: 'tidslinje.antall-uker.17',
                 }, {
                     antallDager: 182,
                     type: 'TID',


### PR DESCRIPTION
Det forvirrer arbeidsgiver at det ser ut som dialogmøtet med NAV skal være rett etter uke 8. Det er derfor flyttet ned til en ny overskrift på uke 17. Det var blitt ganske stor avstand mellom nav-frontendversjoner i digisyfo-npm og sykefravær, så jeg måtte bumpe en god del begge steder for å få dem til å spille på lag.