### PR TITLE
Dato formattering

### DIFF
--- a/js/utils/datoUtils.js
+++ b/js/utils/datoUtils.js
@@ -1,12 +1,12 @@
 export const ANTALL_MS_DAG = 1000 * 60 * 60 * 24;
 
-const erLocalDate = (dato) => { return dato.year && dato.monthValue && dato.dayOfMonth; };
-
 export const toDate = (dato) => {
     if (typeof dato === 'undefined' || dato === null) {
         return null;
+    } else if (typeof date === 'string' && dato.includes('T') && !dato.includes('Z')) {
+        return new Date(`${dato}Z`);
     }
-    return erLocalDate(dato) ? new Date(dato.year, dato.monthValue - 1, dato.dayOfMonth) : new Date(dato);
+    return new Date(dato);
 };
 
 export const toDatePrettyPrint = (dato) => {
@@ -16,9 +16,9 @@ export const toDatePrettyPrint = (dato) => {
 
     const _dato = toDate(dato);
 
-    const days = _dato.getDate() < 10 ? `0${_dato.getDate()}` : `${_dato.getDate()}`;
-    const months = _dato.getMonth() + 1 < 10 ? `0${_dato.getMonth() + 1}` : `${_dato.getMonth() + 1}`;
-    const years = _dato.getFullYear();
+    const days = _dato.getUTCDate() < 10 ? `0${_dato.getUTCDate()}` : `${_dato.getUTCDate()}`;
+    const months = _dato.getUTCMonth() + 1 < 10 ? `0${_dato.getUTCMonth() + 1}` : `${_dato.getUTCMonth() + 1}`;
+    const years = _dato.getUTCFullYear();
 
     return `${days}.${months}.${years}`;
 };
@@ -57,14 +57,14 @@ const SKILLETEGN_PERIODE = '–';
 
 export const langtDatoFormat = (_dato) => {
     const dato = new Date(_dato);
-    return `${dato.getDate()}. ${maaneder[dato.getMonth()]} ${dato.getFullYear()}`;
+    return `${dato.getUTCDate()}. ${maaneder[dato.getUTCMonth()]} ${dato.getUTCFullYear()}`;
 };
 
 export const tilLesbarDatoUtenAarstall = (datoArg) => {
     if (datoArg) {
         const dato = new Date(datoArg);
-        const dag = dato.getDate();
-        const manedIndex = dato.getMonth();
+        const dag = dato.getUTCDate();
+        const manedIndex = dato.getUTCMonth();
         const maned = maaneder[manedIndex];
         return `${dag}. ${maned}`;
     }
@@ -73,17 +73,17 @@ export const tilLesbarDatoUtenAarstall = (datoArg) => {
 
 export const tilLesbarDatoMedArstall = (datoArg) => {
     return datoArg
-        ? `${tilLesbarDatoUtenAarstall(new Date(datoArg))} ${new Date(datoArg).getFullYear()}`
+        ? `${tilLesbarDatoUtenAarstall(new Date(datoArg))} ${new Date(datoArg).getUTCFullYear()}`
         : null;
 };
 
 export const tilLesbarPeriodeMedArstall = (fomArg, tomArg) => {
     const fom = new Date(fomArg);
     const tom = new Date(tomArg);
-    const erSammeAar = fom.getFullYear() === tom.getFullYear();
-    const erSammeMaaned = fom.getMonth() === tom.getMonth();
+    const erSammeAar = fom.getUTCFullYear() === tom.getUTCFullYear();
+    const erSammeMaaned = fom.getUTCMonth() === tom.getUTCMonth();
     return erSammeAar && erSammeMaaned
-        ? `${fom.getDate()}. ${SKILLETEGN_PERIODE} ${tilLesbarDatoMedArstall(tom)}`
+        ? `${fom.getUTCDate()}. ${SKILLETEGN_PERIODE} ${tilLesbarDatoMedArstall(tom)}`
         : erSammeAar
             ? `${tilLesbarDatoUtenAarstall(fom)} ${SKILLETEGN_PERIODE} ${tilLesbarDatoMedArstall(tom)}`
             : `${tilLesbarDatoMedArstall(fom)} ${SKILLETEGN_PERIODE} ${tilLesbarDatoMedArstall(tom)}`;
@@ -92,8 +92,8 @@ export const tilLesbarPeriodeMedArstall = (fomArg, tomArg) => {
 export const tilLesbarPeriodeUtenArstall = (fomArg, tomArg) => {
     const fom = new Date(fomArg);
     const tom = new Date(tomArg);
-    const erSammeMaaned = fom.getMonth() === tom.getMonth();
+    const erSammeMaaned = fom.getUTCMonth() === tom.getUTCMonth();
     return erSammeMaaned
-        ? `${fom.getDate()}. ${SKILLETEGN_PERIODE} ${tilLesbarDatoUtenAarstall(tom)}`
+        ? `${fom.getUTCDate()}. ${SKILLETEGN_PERIODE} ${tilLesbarDatoUtenAarstall(tom)}`
         : `${tilLesbarDatoUtenAarstall(fom)} ${SKILLETEGN_PERIODE} ${tilLesbarDatoUtenAarstall(tom)}`;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/digisyfo-npm",
-  "version": "17.3.0",
+  "version": "17.3.1",
   "description": "Felleskomponenter for DigiSyfo - Digitalisering av sykefraværsoppfølgingen",
   "main": "lib/index.js",
   "files": [

--- a/tests/utils/datoUtilsTest.js
+++ b/tests/utils/datoUtilsTest.js
@@ -15,15 +15,15 @@ import {
 describe('datoUtils', () => {
     describe('toDatePrettyPrint', () => {
         it('Skal formatere dato', () => {
-            expect(toDatePrettyPrint({ year: 2014, monthValue: 2, dayOfMonth: 28 })).to.equal('28.02.2014');
+            expect(toDatePrettyPrint(new Date('2014-02-28'))).to.equal('28.02.2014');
         });
 
         it('Skal ta hensyn til tidssoner', () => {
-            expect(toDatePrettyPrint({ year: 2016, monthValue: 5, dayOfMonth: 10 })).to.equal('10.05.2016');
+            expect(toDatePrettyPrint(new Date('2016-05-10'))).to.equal('10.05.2016');
         });
 
         it('Skal ta hensyn til skuddår', () => {
-            expect(toDatePrettyPrint({ year: 1984, monthValue: 2, dayOfMonth: 29 })).to.equal('29.02.1984');
+            expect(toDatePrettyPrint(new Date('1984-02-29'))).to.equal('29.02.1984');
         });
 
         it('Kan formattere dato på ISO-format', () => {
@@ -37,8 +37,8 @@ describe('datoUtils', () => {
 
     describe('getDuration', () => {
         it('Skal regne ut varighet', () => {
-            expect(getDuration({ year: 2014, monthValue: 2, dayOfMonth: 27 }, { year: 2014, monthValue: 3, dayOfMonth: 8 })).to.equal(10);
-            expect(getDuration({ year: 2014, monthValue: 6, dayOfMonth: 30 }, { year: 2014, monthValue: 7, dayOfMonth: 5 })).to.equal(6);
+            expect(getDuration(new Date('2014-02-27'), new Date('2014-03-08'))).to.equal(10);
+            expect(getDuration(new Date('2014-06-30'), new Date('2014-07-05'))).to.equal(6);
         });
 
         it('Kan regne ut varighet på ISO-format', () => {
@@ -109,7 +109,7 @@ describe('datoUtils', () => {
 
     describe('langtDatoFormat', () => {
         it('Skal returnere 25. september 2017', () => {
-            const d = langtDatoFormat(new Date(2017, 8, 25));
+            const d = langtDatoFormat(new Date('2017-09-25'));
             expect(d).to.equal('25. september 2017');
         });
         it('Takler å få tekst-dato inn', () => {

--- a/tests/utils/sykmeldingUtilsTest.js
+++ b/tests/utils/sykmeldingUtilsTest.js
@@ -19,16 +19,16 @@ describe('getSykmelding', () => {
 describe('getPeriodeSpenn', () => {
     it('skal returnere antall dager mellom startdato i første periode og sluttdato i siste periode', () => {
         const perioder = [{
-            fom: { year: 2015, monthValue: 1, dayOfMonth: 1 },
-            tom: { year: 2015, monthValue: 1, dayOfMonth: 2 },
+            fom: new Date('2015-01-01'),
+            tom: new Date('2015-01-02'),
             grad: '100',
         }, {
-            fom: { year: 2015, monthValue: 1, dayOfMonth: 1 },
-            tom: { year: 2015, monthValue: 1, dayOfMonth: 3 },
+            fom: new Date('2015-01-01'),
+            tom: new Date('2015-01-03'),
             grad: '100',
         }, {
-            fom: { year: 2015, monthValue: 1, dayOfMonth: 1 },
-            tom: { year: 2015, monthValue: 1, dayOfMonth: 20 },
+            fom: new Date('2015-01-01'),
+            tom: new Date('2015-01-20'),
             grad: '100',
         }];
         const p = utils.getPeriodeSpenn(perioder);
@@ -42,33 +42,33 @@ describe('getSykmeldingStartdato', () => {
             id: 1,
             mulighetForArbeid: {
                 perioder: [{
-                    fom: { year: 2014, monthValue: 1, dayOfMonth: 1 },
-                    tom: { year: 2014, monthValue: 1, dayOfMonth: 10 },
+                    fom: new Date('2014-01-01'),
+                    tom: new Date('2014-01-10'),
                     grad: '80',
                 }, {
-                    fom: { year: 2014, monthValue: 2, dayOfMonth: 2 },
-                    tom: { year: 2014, monthValue: 2, dayOfMonth: 5 },
+                    fom: new Date('2014-02-02'),
+                    tom: new Date('2014-02-05'),
                     grad: '80',
                 }],
             },
         });
-        expect(res1).to.deep.equal({ year: 2014, monthValue: 1, dayOfMonth: 1 });
+        expect(res1).to.deep.equal(new Date('2014-01-01'));
 
         const res2 = utils.getSykmeldingStartdato({
             id: 1,
             mulighetForArbeid: {
                 perioder: [{
-                    fom: { year: 2014, monthValue: 1, dayOfMonth: 1 },
-                    tom: { year: 2014, monthValue: 1, dayOfMonth: 10 },
+                    fom: new Date('2014-01-01'),
+                    tom: new Date('2014-01-10'),
                     grad: '80',
                 }, {
-                    fom: { year: 2012, monthValue: 2, dayOfMonth: 2 },
-                    tom: { year: 2014, monthValue: 2, dayOfMonth: 5 },
+                    fom: new Date('2012-02-02'),
+                    tom: new Date('2014-02-05'),
                     grad: '80',
                 }],
             },
         });
-        expect(res2).to.deep.equal({ year: 2012, monthValue: 2, dayOfMonth: 2 });
+        expect(res2).to.deep.equal(new Date('2012-02-02'));
     });
 });
 


### PR DESCRIPTION
- Enderer toDate() parsing av datostrenger til å defaulte til UTC
- Fjerner custom dato-format: `const erLocalDate = (dato) => { return dato.year && dato.monthValue && dato.dayOfMonth; };`
- Fikser tester